### PR TITLE
switched to using fetch since its unclear why axios quit parsing json

### DIFF
--- a/pages/adopt/index.tsx
+++ b/pages/adopt/index.tsx
@@ -19,8 +19,10 @@ const Adopt = ({ animals, updatedAt }: AdoptProps) => {
 	useEffect(() => {
 		console.log("Animals last updated at: ", updatedAt);
 		const getAnimalsForPage = async () => {
-			const newJSONAnimals = (await axios.get(`/api/animals`)).data;
-			const newAnimals = JSON.parse(newJSONAnimals) as Animal[];
+			const response = await fetch(`/api/animals`);
+			const responseJson = await response.json();
+			const newAnimals: Animal[] = await JSON.parse(responseJson);
+
 			setCurrentAnimals(newAnimals);
 		};
 		getAnimalsForPage();


### PR DESCRIPTION
Since it's unclear why Axios stopped automatically parsing the JSON (some similar issues reported were due to errors in the JSON parsing, however this does not appear to be the case here since manually parsing the JSON works fine), switching to fetch and performing the JSON parsing operation using JSON.parse() seems to be the safer way to go since Axios is unreliable. Just adding the manual parsing for the Axios call might break if Axios suddenly starts working again.

Fixes #63 