### PR TITLE
Update site for 2023

### DIFF
--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -9,7 +9,7 @@ const Footer = () => {
 				<FooterNavigation />
 				<FooterLogo />
 				<div className={styles.copyright}>
-					<p>© 2022 Pals of Paws Society. All Rights Reserved.</p>
+					<p>© 2023 Pals of Paws Society. All Rights Reserved.</p>
 				</div>
 			</div>
 		</footer>

--- a/components/homepage/AnimalCounter.tsx
+++ b/components/homepage/AnimalCounter.tsx
@@ -15,7 +15,7 @@ interface AnimalCounterProps {
 const AnimalCounter = ({ catCount, dogCount }: AnimalCounterProps) => {
 	return (
 		<div className={styles.counters}>
-			<p>So far, in 2022, we have helped</p>
+			<p>Since 2022, we have helped</p>
 			<div className={styles.petCounter}>
 				<div className={styles.icon}>
 					<Image

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -119,8 +119,8 @@ export const getStaticProps: GetStaticProps = async () => {
 		sheetId: catSheetId,
 	});
 
-	const catCount = catSheetData?.length || 381;
-	const dogCount = dogSheetData?.length || 160;
+	const catCount = catSheetData?.length || 751;
+	const dogCount = dogSheetData?.length || 208;
 
 	return {
 		props: { catCount, dogCount },


### PR DESCRIPTION
Changed homepage language "So far, in 2022..." to "Since 2022, ...".
Updated fallback numbers if spreadsheet doesn't load.

Updated footer copyright to 2023.