### PR TITLE
GA Cron Update

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -1,14 +1,14 @@
 name: Animals Cache
 on:
-    schedule:
-        - cron: "0 * * * *"
-    workflow_dispatch:
+  schedule:
+    - cron: "0 */2 * * *"
+  workflow_dispatch:
 jobs:
-    animals:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Refresh Animals Cache
-              run: |
-                  curl --request POST \
-                  --url 'https://www.palsofpawssociety.org/api/animals' \
-                  --header 'token: ${{ secrets.API_TOKEN }}'
+  animals:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refresh Animals Cache
+        run: |
+          curl --request POST \
+          --url 'https://www.palsofpawssociety.org/api/animals' \
+          --header 'token: ${{ secrets.API_TOKEN }}'


### PR DESCRIPTION
Update Github Actions Cron job to run every two hours instead of every hour to reduce usage.